### PR TITLE
[DOCS] Add CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CODEOWNERS for OSS compliance (#14)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @clafollett

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [YOUR_EMAIL_HERE]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
+
+[homepage]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to FDIC BankFind MCP Server
+
+Thank you for your interest in contributing! We welcome contributions of all kinds—code, documentation, tests, and more.
+
+## How to Contribute
+
+- **Bug Reports & Feature Requests:** Use GitHub Issues. Please use the provided templates in `.github/ISSUE_TEMPLATE`.
+- **Pull Requests:**
+  - Fork the repo and create a branch from `main` (use the issue number in your branch name if possible).
+  - Ensure your code is idiomatic Rust, well-documented, and passes `cargo check` and `cargo test`.
+  - Add/maintain comprehensive unit tests for all new features and error cases.
+  - Follow the project’s [Prime Directive](./.windsurfrules) and coding standards.
+  - Reference relevant issues in your PR description.
+- **Code Reviews:** All PRs require review by a code owner.
+
+## Code Style
+- Follow Rust conventions (`rustfmt` is enforced).
+- Organize imports as described in `.windsurfrules`.
+- Document all public types and functions.
+
+## Communication
+- Be respectful and constructive.
+- See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+
+## Questions?
+Open an issue or discussion on GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it by emailing [YOUR_EMAIL_HERE]. Do not create public GitHub issues for security-related problems.
+
+- We will respond as quickly as possible and keep you informed of our progress.
+- Once the vulnerability is resolved, we will disclose the issue and fix in a coordinated manner.
+
+## Supported Versions
+
+We generally support the latest major release. Older versions may not receive security updates.
+
+## Disclosure Policy
+
+Responsible disclosure is appreciated and encouraged.


### PR DESCRIPTION
[#14] Add contributor and compliance docs for OSS best practices

- Add CONTRIBUTING.md with guidelines for PRs, code style, and reviews
- Add CODE_OF_CONDUCT.md (Contributor Covenant v2.1) for community standards
- Add SECURITY.md for vulnerability reporting and disclosure policy
- Add .github/CODEOWNERS to clarify code ownership and review requirements
- Ensure all new docs are discoverable and compliant with GitHub OSS standards
- Improves onboarding, governance, and contributor experience per Issue #14
